### PR TITLE
fix: hometypes typo

### DIFF
--- a/client/src/components/SearchOption/SearchButtons/HomeType.js
+++ b/client/src/components/SearchOption/SearchButtons/HomeType.js
@@ -17,7 +17,13 @@ const StyledButton = muiStyled(Button)({
 });
 
 export default function HomeType() {
-  const homeTypes = ['Apartment', 'House', 'Condo', 'Townhome', 'Multi-family'];
+  const homeTypes = [
+    'Apartments',
+    'Condos',
+    'Houses',
+    'Multi-family',
+    'Townhomes',
+  ];
   const searchParams = useSelector(state => state.search);
 
   const [anchorEl, setAnchorEl] = useState(null);


### PR DESCRIPTION
## :: Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Edit convention

<br />

## :: Description
- fix typo in home_type ENUM to correspond to Zillow support option
<br />
